### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ dependencies {
     implementation group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2"
 
     // configuration
-    implementation "com.typesafe:config:1.3.3"
+    api "com.typesafe:config:1.3.3"
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")


### PR DESCRIPTION
feat: make com.typesafe:config library transient

### Motivation and Context

The Harvest client needs a `com.typesafe.config.Config` object input as configuration, so it will be the best to expose   `com.typesafe.config` dependency as a transient library so that projects that uses this library could use this client without adding any additional dependencies
