### PR TITLE
feat: make typesafe library transient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ dependencies {
     implementation group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2"
 
     // configuration
-    implementation "com.typesafe:config:1.3.3"
+    api "com.typesafe:config:1.3.3"
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")


### PR DESCRIPTION

### Checklist

- [ ] I've run `./gradlew test` from the root directory to see all new and existing tests pass
- [ ] I've followed the _harvest-client_ code style
- [ ] I've read the [Contribution Guidelines][contribution guidelines]
- [ ] I've updated the documentation if necessary.

### Motivation and Context
The Harvest client needs a com.typesafe.config.Config object input as configuration, so it will be the best to expose com.typesafe.config dependency as a transient library so that projects that uses this library could use this client without adding any additional dependencies

### Description
