### PR TITLE
ci: publish to GitHub Packages instead of Maven Central

### DIFF
--- a/.github/workflows/build-and-publish-jar.yml
+++ b/.github/workflows/build-and-publish-jar.yml
@@ -1,4 +1,4 @@
-name: Publish jar to Maven Central
+name: Publish jar to GitHub Packages
 
 on:
   push:
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-publish-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
 
       - name: Checkout
@@ -28,18 +31,9 @@ jobs:
           HARVEST_AUTH_TOKEN_ADMIN2: ${{ secrets.HARVEST_AUTH_TOKEN_ADMIN2 }}
         run: ./gradlew build
 
-      - name: Decode the signing key
-        run: |
-          echo 'ORG_GRADLE_PROJECT_signingKey<<EOF' >> $GITHUB_ENV
-          echo $ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64 | base64 --decode >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+      - name: Publish to GitHub Packages
         env:
-          ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64 }}
-
-      - name: Publish image
-        env:
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
+          GH_USERNAME: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./gradlew publishAllPublicationsToSonatypeRepository closeAndReleaseRepository
+          ./gradlew publishGprPublicationToGitHubPackagesRepository

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,6 @@ plugins {
     // test coverage
     id 'jacoco'
     id 'eclipse'
-
-    // publishing to Maven Central
-    id "signing" // maven central requirement
-    id "io.codearte.nexus-staging" version "0.22.0"
-    id "de.marcphilipp.nexus-publish" version "0.4.0"
 }
 
 group 'ch.aaap'
@@ -110,53 +105,6 @@ publishing {
             }
         }
     }
-}
-
-def hasSigningKey = project.hasProperty("signingKeyId") || project.hasProperty("signingKey")
-if (hasSigningKey) {
-    sign(project)
-}
-
-void sign(Project project) {
-    project.signing {
-        required { project.gradle.taskGraph.hasTask("publish") }
-        def signingKeyId = project.findProperty("signingKeyId")
-        def signingKey = project.findProperty("signingKey")
-        def signingPassword = project.findProperty("signingPassword")
-        if (signingKeyId) {
-            useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-        } else if (signingKey) {
-            useInMemoryPgpKeys(signingKey, signingPassword)
-        }
-        sign publishing.publications.gpr
-    }
-}
-
-nexusStaging {
-    if (project.hasProperty("sonatypeUsername")) {
-        username = project.sonatypeUsername
-    }
-    if (project.hasProperty("sonatypePassword")) {
-        password = project.sonatypePassword
-    }
-    repositoryDescription = "Release ${project.group} ${project.name} ${project.version}"
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            if (project.hasProperty("sonatypeUsername")) {
-                username = project.sonatypeUsername
-            }
-            if (project.hasProperty("sonatypePassword")) {
-                password = project.sonatypePassword
-            }
-        }
-    }
-    // these are not strictly required. The default timeouts are set to 1 minute. But Sonatype can be really slow.
-    // If you get the error "java.net.SocketTimeoutException: timeout", these lines will help.
-    connectTimeout = Duration.ofMinutes(5)
-    clientTimeout = Duration.ofMinutes(5)
 }
 
 dependencies {


### PR DESCRIPTION
🔑

## Problem

Publishing 1.1.8 to Maven Central failed:

```
Execution failed for task ':initializeSonatypeStagingRepository'.
> Failed to load staging profiles, server responded with status code 402
```

Sonatype **OSSRH shut down on 30 June 2025**. The `io.codearte.nexus-staging` and `de.marcphilipp.nexus-publish` plugins only speak to the retired `oss.sonatype.org` endpoint, so this publish path can no longer succeed. (The successor is the Central Publishing Portal, which needs a namespace migration + a different plugin.)

## Approach

harvest-client is only consumed internally (`3ap-admin-services`), and build.gradle already had a **GitHub Packages** publication configured. So rather than migrate to the Central Portal, publish to GitHub Packages.

### Changes
- Remove the `signing`, `io.codearte.nexus-staging`, and `de.marcphilipp.nexus-publish` plugins and their `nexusStaging {}` / `nexusPublishing {}` / signing config blocks.
- Publish workflow now runs `publishGprPublicationToGitHubPackagesRepository` using the built-in `GITHUB_TOKEN` (`packages: write`), dropping the Sonatype credentials and GPG signing steps.
- Workflow still triggers on push to `master` (git-flow release unchanged).

## ⚠️ Consumer action required

Consumers must resolve harvest-client from GitHub Packages, which requires authentication. In `3ap-admin-services`:

```xml
<repository>
  <id>github-3ap</id>
  <url>https://maven.pkg.github.com/3AP-AG/harvest-client</url>
</repository>
```

plus a GitHub token (with `read:packages`) in their Maven `settings.xml` / CI. GitHub Packages does **not** allow anonymous downloads.

## Notes
- No version bump here — this is the publishing-infra fix on `develop`. The actual re-release (cutting a release branch → `master`) happens separately once this lands.
- Signed artifacts are no longer produced; GitHub Packages does not require GPG signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)