### PR TITLE
ci: publish to Maven Central via the Central Portal upload API

### DIFF
--- a/.github/workflows/build-and-publish-jar.yml
+++ b/.github/workflows/build-and-publish-jar.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+  # Allows a manual run (e.g. against develop) to validate the full
+  # publish pipeline without cutting a release. With USER_MANAGED uploads
+  # nothing is published until it is released in the Portal UI.
+  workflow_dispatch:
 
 jobs:
   build-and-publish-image:

--- a/.github/workflows/build-and-publish-jar.yml
+++ b/.github/workflows/build-and-publish-jar.yml
@@ -36,10 +36,27 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64 }}
 
-      - name: Publish image
+      - name: Publish signed artifacts to local staging repo
         env:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
+        run: ./gradlew publish
+
+      - name: Assemble Central Portal bundle
         run: |
-          ./gradlew publishAllPublicationsToSonatypeRepository closeAndReleaseRepository
+          cd build/staging-deploy
+          zip -r ../central-bundle.zip ch -x '*maven-metadata*'
+
+      - name: Upload bundle to Central Portal
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+        run: |
+          # publishingType=USER_MANAGED: after validation, release manually in the
+          # Portal UI. Switch to AUTOMATIC once the pipeline is proven to auto-release.
+          TOKEN=$(printf '%s:%s' "$CENTRAL_USERNAME" "$CENTRAL_PASSWORD" | base64 -w0)
+          DEPLOYMENT_ID=$(curl -sS --fail-with-body -X POST \
+            "https://central.sonatype.com/api/v1/publisher/upload?name=harvest-client-run-${{ github.run_number }}&publishingType=USER_MANAGED" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -F "bundle=@build/central-bundle.zip")
+          echo "Central Portal deployment id: ${DEPLOYMENT_ID}"
+          echo "Validate and release it at https://central.sonatype.com/publishing/deployments"

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,8 @@ plugins {
     id 'jacoco'
     id 'eclipse'
 
-    // publishing to Maven Central
+    // publishing to Maven Central (via the Central Portal upload API, see below)
     id "signing" // maven central requirement
-    id "io.codearte.nexus-staging" version "0.22.0"
-    id "de.marcphilipp.nexus-publish" version "0.4.0"
 }
 
 group 'ch.aaap'
@@ -82,19 +80,22 @@ javadoc {
     options.optionFiles << file('gradle/javadoc.options')
 }
 
+// Central Portal expects a plain Maven bundle; Gradle Module Metadata (.module)
+// files are not needed by Maven consumers and can fail Portal validation.
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
+
 // Create the publication with the pom configuration:
 
 publishing {
     repositories {
+        // Local staging repository. `./gradlew publish` writes the signed
+        // artifacts here in Maven layout; the release workflow then zips this
+        // directory into a bundle and uploads it to the Central Portal API.
         maven {
-            name = "GitHubPackages"
-            String owner = '3ap-ag'
-            String repo = 'harvest-client'
-            url = uri("https://maven.pkg.github.com/${owner}/${repo}")
-            credentials {
-                username = project.findProperty("gpr.user") ?: System.getenv("GH_USERNAME")
-                password = project.findProperty("gpr.key") ?: System.getenv("GH_TOKEN")
-            }
+            name = "staging"
+            url = uri("${buildDir}/staging-deploy")
         }
     }
     publications {
@@ -130,33 +131,6 @@ void sign(Project project) {
         }
         sign publishing.publications.gpr
     }
-}
-
-nexusStaging {
-    if (project.hasProperty("sonatypeUsername")) {
-        username = project.sonatypeUsername
-    }
-    if (project.hasProperty("sonatypePassword")) {
-        password = project.sonatypePassword
-    }
-    repositoryDescription = "Release ${project.group} ${project.name} ${project.version}"
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            if (project.hasProperty("sonatypeUsername")) {
-                username = project.sonatypeUsername
-            }
-            if (project.hasProperty("sonatypePassword")) {
-                password = project.sonatypePassword
-            }
-        }
-    }
-    // these are not strictly required. The default timeouts are set to 1 minute. But Sonatype can be really slow.
-    // If you get the error "java.net.SocketTimeoutException: timeout", these lines will help.
-    connectTimeout = Duration.ofMinutes(5)
-    clientTimeout = Duration.ofMinutes(5)
 }
 
 dependencies {


### PR DESCRIPTION
🔑

## Why

Publishing to Maven Central broke after Sonatype **shut down OSSRH (30 June 2025)**:

```
Execution failed for task ':initializeSonatypeStagingRepository'.
> Failed to load staging profiles, server responded with status code 402
```

The `io.codearte.nexus-staging` / `de.marcphilipp.nexus-publish` plugins only speak to the retired OSSRH endpoint. Publishing now goes through the **Central Publishing Portal**.

## Approach — keep it public, keep the churn low

We want to stay on Maven Central (`ch.aaap:harvest-client`) since there are external users. The obvious plugin (vanniktech) now **requires Gradle 9** — a 7.2→9 jump we don't want for a publish config. So instead we upload to the Central Portal's HTTP API directly, reusing the existing (working) `maven-publish` + `signing` on Gradle 7.2.

### Changes
- Remove the dead `nexus-staging` / `nexus-publish` plugins and their config blocks.
- Publish the signed publication to a **local staging repo** (`build/staging-deploy`) in Maven layout.
- **Disable Gradle Module Metadata** (`.module`) so the bundle is a plain Maven bundle the Portal accepts.
- Release workflow zips the staging repo and `POST`s it to `https://central.sonatype.com/api/v1/publisher/upload` (`publishingType=USER_MANAGED` — first deployments are validated then released manually in the Portal UI; flip to `AUTOMATIC` once proven).

## Verified locally (JDK 17)
`./gradlew publish` produces the correct bundle:
```
harvest-client-<v>.jar / -sources.jar / -javadoc.jar / .pom
  + .md5 / .sha1 / .sha256 / .sha512 each
no .module, no maven-metadata in the bundle
```
Signatures (`.asc`) are added in CI via the in-memory GPG key (BouncyCastle — no `gpg` binary needed) and are included because the zip captures everything under `ch/`.

## Required repo secrets before the next release
- `CENTRAL_TOKEN_USERNAME` / `CENTRAL_TOKEN_PASSWORD` — from central.sonatype.com → **Generate User Token**.
- Existing signing secrets: `ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64`, `ORG_GRADLE_PROJECT_SIGNINGPASSWORD`.

## ⚠️ One prerequisite only you can do
The **public half of the signing key must be on a public keyserver** (e.g. `keys.openpgp.org`) or the Portal will reject the signatures. If the key used for 1.1.7 is still around and already uploaded, you're set; if it's a new key, publish it first.

## Notes
- No version bump here (infra only). The re-release happens by cutting a release branch → `master`, which triggers this workflow.
- This supersedes the GitHub Packages PR (#22), which should be closed — Packages is auth-only and can't serve public users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)