### PR TITLE
ci: auto-regenerate javadoc on release branches

### DIFF
--- a/.github/workflows/refresh-docs.yml
+++ b/.github/workflows/refresh-docs.yml
@@ -1,0 +1,44 @@
+name: Refresh javadoc on release branches
+
+# Keeps the committed docs/ (served by GitHub Pages from master/docs) in sync
+# with the released version. Runs on release branches only and commits the
+# regenerated javadoc back to the release branch, so the refreshed docs reach
+# master through the normal (reviewed) release PR — no direct push to the
+# protected master branch is needed.
+on:
+  push:
+    branches:
+      - 'release/**'
+
+permissions:
+  contents: write
+
+jobs:
+  refresh-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Regenerate javadoc
+        run: ./gradlew javadoc
+
+      - name: Commit refreshed docs if changed
+        run: |
+          if [ -n "$(git status --porcelain docs)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add docs
+            # [skip ci] avoids re-triggering workflows on the docs commit
+            git commit -m "docs: regenerate javadoc for ${GITHUB_REF_NAME} [skip ci]"
+            git push
+          else
+            echo "docs already up to date"
+          fi


### PR DESCRIPTION
🔑

## What
Adds `.github/workflows/refresh-docs.yml`: on any push to a `release/**` branch, regenerate javadoc and commit `docs/` back to that branch.

## Why
`docs/` is committed generated javadoc served by GitHub Pages from `master/docs`. It drifted (showed 1.1.7 through the 1.1.9 release) because nothing refreshed it on release. This closes that gap automatically.

## Why this shape (given branch protection)
`master` requires a reviewed PR, so a workflow can't push `docs/` straight to it. Instead this runs on the **unprotected `release/**` branch**, and the refreshed docs reach `master` through the normal reviewed release PR — the same path the version bump already takes.

### Notes
- Uses the built-in `GITHUB_TOKEN` (`contents: write`) to push to the release branch; such pushes don't retrigger workflows, and the commit is tagged `[skip ci]` as a belt-and-suspenders guard.
- Same Temurin 17 toolchain as the other jobs, so the diff stays minimal (just the version + any real code-driven doc changes).
- The one-off refresh for the already-shipped 1.1.9 is handled separately in #26 (→ master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)